### PR TITLE
multiple fixes for code audit

### DIFF
--- a/src/AsBnbMinter.sol
+++ b/src/AsBnbMinter.sol
@@ -246,7 +246,7 @@ contract AsBnbMinter is
   ) external payable override whenNotPaused depositEnabled nonReentrant returns (uint256) {
     // get cross chain fee and validate the existence of OFTAdapter
     MessagingFee memory fee = getCrossChainFee(sendParam);
-    require(msg.value >= fee.nativeFee, "Invalid fee");
+    require(msg.value == fee.nativeFee, "Invalid fee");
     // transfer token from user to this contract
     token.safeTransferFrom(msg.sender, address(this), amountIn);
 

--- a/src/YieldProxy.sol
+++ b/src/YieldProxy.sol
@@ -297,17 +297,6 @@ contract YieldProxy is
   }
 
   /**
-   * @dev Delegate all tokens to a new MPC Wallet
-   * @notice When Lista has announced in advance that the MPC wallet will be changed,
-   *         manager(multi-sig) can call this function to delegate all tokens to the new MPC wallet
-   */
-  function reDelegateTokens() external onlyRole(MANAGER) whenNotPaused {
-    require(slisBNBProvider != address(0), "slisBNBProvider not set");
-    require(mpcWallet != address(0), "mpcWallet not set");
-    ISlisBNBProvider(slisBNBProvider).delegateAllTo(mpcWallet);
-  }
-
-  /**
    * @dev convert all slisBNB to clisBNB
    */
   function convertAllSlisBNBToClisBNB() external onlyRole(MANAGER) whenNotPaused {
@@ -338,7 +327,10 @@ contract YieldProxy is
   function setMPCWallet(address _mpcWallet) external onlyRole(MANAGER) {
     require(_mpcWallet != address(0) && _mpcWallet != mpcWallet, "Invalid MPC wallet address");
     address oldMpcWallet = mpcWallet;
+    // update mpc wallet
     mpcWallet = _mpcWallet;
+    // delegate all to the new MPC wallet right after it's updated
+    ISlisBNBProvider(slisBNBProvider).delegateAllTo(mpcWallet);
     emit MPCWalletSet(oldMpcWallet, _mpcWallet);
   }
 

--- a/src/oft/AsBnbOFT.sol
+++ b/src/oft/AsBnbOFT.sol
@@ -40,6 +40,11 @@ contract AsBnbOFT is
     string memory _symbol,
     address _delegate
   ) external initializer {
+    require(_admin != address(0), "Invalid admin address");
+    require(_manager != address(0), "Invalid manager address");
+    require(_pauser != address(0), "Invalid pauser address");
+    require(_delegate != address(0), "Invalid delegate address");
+
     __OFT_init(_name, _symbol, _delegate);
     __Ownable_init(_delegate);
     __AccessControl_init();

--- a/src/oft/AsBnbOFTAdapter.sol
+++ b/src/oft/AsBnbOFTAdapter.sol
@@ -42,6 +42,11 @@ contract AsBnbOFTAdapter is
     address _pauser,
     address _delegate
   ) external initializer {
+    require(_admin != address(0), "Invalid admin address");
+    require(_manager != address(0), "Invalid manager address");
+    require(_pauser != address(0), "Invalid pauser address");
+    require(_delegate != address(0), "Invalid delegate address");
+
     __OFTAdapter_init(_delegate);
     __Ownable_init(_admin);
     __AccessControl_init();


### PR DESCRIPTION
multiple fixes for code audit
1. user must pay the exact fare for minting asBNB with slisBNB to another chain
2. removed `reDelegateTokens()` and merge it's logics to `setMPCWallet()`
3. added non-zero address assertions for asBnbOFT and asBnbOFTAdapter